### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.0...v0.1.1) - 2025-08-12
+
+### Fixed
+
+- Correct license
+
+### Other
+
+- Change GitHub link again
+# Changelog
+
 Notable changes to this project will be documented in this file.
 
 ## [0.1.0]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "serde-ply"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "byteorder",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-ply"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Arthur Brussee <arthur.brussee@gmail.com>"]
 description = "A Serde-based PLY (Polygon File Format) serializer and deserializer"


### PR DESCRIPTION



## 🤖 New release

* `serde-ply`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.0...v0.1.1) - 2025-08-12

### Fixed

- Correct license

### Other

- Change GitHub link again
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).