### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.1...v0.1.2) - 2025-08-13
+
+### Added
+
+- Improve API & documentation
+- improve documentation
+
+### Other
+
+- More docs improvments
+- Serialize with "SerializeOptions"
+
 ## [0.1.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.0...v0.1.1) - 2025-08-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "serde-ply"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "byteorder",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-ply"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Arthur Brussee <arthur.brussee@gmail.com>"]
 description = "A Serde-based PLY (Polygon File Format) serializer and deserializer"


### PR DESCRIPTION



## 🤖 New release

* `serde-ply`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.1...v0.1.2) - 2025-08-13

### Added

- Improve API & documentation
- improve documentation

### Other

- More docs improvments
- Serialize with "SerializeOptions"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).