### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Add doc tests
-- Fix release-plz.
+- Fix release-plz
+- Removed ListCountU8 as it's the default anyway
 
 ## [0.1.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.0...v0.1.1) - 2025-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.1...v0.2.0) - 2025-08-13
+
+### Added
+
+- Improve API & documentation
+- improve documentation
+
+### Other
+
+- More docs improvments
+- Serialize with "SerializeOptions"
+
 ## [0.1.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.0...v0.1.1) - 2025-08-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Rename some API to be more consistent (ChunkPlyFile -> PlyChunkedReader, PlyFileDeserializer -> PlyReader)
 - Improve API & documentation
-- improve documentation
+- Serialize with "SerializeOptions" builder for a terser API & ability to set `obj_info`.
 
 ### Other
 
-- More docs improvments
-- Serialize with "SerializeOptions"
+- Add doc tests
+- Fix release-plz.
 
 ## [0.1.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.0...v0.1.1) - 2025-08-12
 
@@ -28,9 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Change GitHub link again
-# Changelog
-
-Notable changes to this project will be documented in this file.
 
 ## [0.1.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "serde-ply"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "byteorder",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-ply"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Arthur Brussee <arthur.brussee@gmail.com>"]
 description = "A Serde-based PLY (Polygon File Format) serializer and deserializer"


### PR DESCRIPTION



## 🤖 New release

* `serde-ply`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `serde-ply` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_parameter_count_changed.ron

Failed in:
  serde_ply::to_bytes now takes 2 parameters instead of 3, in C:\Users\A-Bru\AppData\Local\Temp\.tmp3QXys9\serde_ply\src\ser\mod.rs:80
  serde_ply::to_writer now takes 3 parameters instead of 4, in C:\Users\A-Bru\AppData\Local\Temp\.tmp3QXys9\serde_ply\src\ser\mod.rs:43

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  ScalarType::parse, previously in file C:\Users\A-Bru\AppData\Local\Temp\.tmpICd7Kp\serde-ply\src\lib.rs:49

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct serde_ply::ChunkPlyFile, previously in file C:\Users\A-Bru\AppData\Local\Temp\.tmpICd7Kp\serde-ply\src\de\chunked.rs:15
  struct serde_ply::PlyFileDeserializer, previously in file C:\Users\A-Bru\AppData\Local\Temp\.tmpICd7Kp\serde-ply\src\de\ply_file.rs:13
  struct serde_ply::ListCountU8, previously in file C:\Users\A-Bru\AppData\Local\Temp\.tmpICd7Kp\serde-ply\src\lib.rs:319

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field version of struct PlyHeader, previously in file C:\Users\A-Bru\AppData\Local\Temp\.tmpICd7Kp\serde-ply\src\lib.rs:127

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_missing.ron

Failed in:
  trait serde_ply::ListCountType, previously in file C:\Users\A-Bru\AppData\Local\Temp\.tmpICd7Kp\serde-ply\src\lib.rs:330
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.1...v0.2.0) - 2025-08-13

### Added

- Improve API & documentation
- improve documentation

### Other

- More docs improvments
- Serialize with "SerializeOptions"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).