### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.2.0...v0.2.1) - 2025-08-13
+
+### Fixed
+
+- Handle parsing header when lines end in \r\n
+
+### Other
+
+- release v0.2.0 ([#4](https://github.com/ArthurBrussee/serde_ply/pull/4))
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
 ## [0.2.0](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.1...v0.2.0) - 2025-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.2.1](https://github.com/ArthurBrussee/serde_ply/compare/v0.2.0...v0.2.1) - 2025-08-13
 
 ### Fixed
 
 - Handle parsing header when lines end in \r\n
-
-### Other
-
-- release v0.2.0 ([#4](https://github.com/ArthurBrussee/serde_ply/pull/4))
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
 
 ## [0.2.0](https://github.com/ArthurBrussee/serde_ply/compare/v0.1.1...v0.2.0) - 2025-08-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "serde-ply"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "byteorder",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-ply"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Arthur Brussee <arthur.brussee@gmail.com>"]
 description = "A Serde-based PLY (Polygon File Format) serializer and deserializer"


### PR DESCRIPTION



## 🤖 New release

* `serde-ply`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).